### PR TITLE
Parse FromBody types

### DIFF
--- a/ApiDocumentation/Implementations/SwaggerDocumentationTools.cs
+++ b/ApiDocumentation/Implementations/SwaggerDocumentationTools.cs
@@ -88,9 +88,13 @@ namespace SwaggerAPIDocumentation.Implementations
 			foreach ( var apiDocumentationAttributesAndReturnType in GetApiDocumentationAttributesAndReturnTypes( controllerType ) )
 			{
 				result.Merge( _modelsGenerator.GetModels( apiDocumentationAttributesAndReturnType.Key.ReturnType ?? apiDocumentationAttributesAndReturnType.Value ) );
-			}
 
-			return result;
+                //Get models for parameters
+                if ( apiDocumentationAttributesAndReturnType.Key.FormBody != null )
+                    result.Merge( _modelsGenerator.GetModels(apiDocumentationAttributesAndReturnType.Key.FormBody) );
+            }
+
+            return result;
 		}
 
 		private IEnumerable<MethodInfo> GetControllerMethods( Type controllerType )


### PR DESCRIPTION
Ensures that we fully parse model types and not just the type name, so that they appear as full models in the swagger docs